### PR TITLE
Fix sort_links helper for very similar fileds

### DIFF
--- a/lib/ex_sieve_html/sort_link.ex
+++ b/lib/ex_sieve_html/sort_link.ex
@@ -3,6 +3,7 @@ defmodule ExSieve.HTML.SortLink do
 
   import Phoenix.HTML.Link, only: [link: 2]
 
+  @direction_separator " "
   @directions ~w(desc asc)
   @direction_symbols %{"asc" => "▼", "desc" => "▲"}
   @sort_key "s"
@@ -46,7 +47,7 @@ defmodule ExSieve.HTML.SortLink do
             default_dir
           end
 
-    params = put_in(params, path, "#{field} #{dir}")
+    params = put_in(params, path, "#{field}#{@direction_separator}#{dir}")
 
     {params, dir}
   end
@@ -66,7 +67,7 @@ defmodule ExSieve.HTML.SortLink do
   end
 
   defp same_field?(value, field) do
-    value |> String.starts_with?(to_string(field))
+    value |> String.starts_with?("#{to_string(field)}#{@direction_separator}")
   end
 
   defp parse_direction(value) do

--- a/test/ex_sieve_html/sort_link_test.exs
+++ b/test/ex_sieve_html/sort_link_test.exs
@@ -38,7 +38,7 @@ defmodule ExSieve.HTML.SortLinkTest do
       assert html == result
     end
 
-    test "return default dirrection for new s value", %{conn: conn} do
+    test "return default direction for new s value", %{conn: conn} do
       html = ~s(<a class=\"desc\" href=\"/?q[s]=id+desc\">test</a>)
 
       result =
@@ -68,6 +68,18 @@ defmodule ExSieve.HTML.SortLinkTest do
       result =
         conn
         |> Plug.Parsers.call([])
+        |> ExSieve.HTML.sort_link(:name, "test", to: &(assert_params_path(conn, :search, &1)))
+        |> Phoenix.HTML.safe_to_string
+
+      assert html == result
+    end
+
+    test "doesn't append arrow when field not sorted yet but very similar", %{conn: conn} do
+      html = ~s(<a class=\"desc\" href=\"/?q[s]=name+desc\">test</a>)
+
+      result =
+        conn
+        |> Map.put(:params, %{"q" => %{"s" => "name_foo desc"}})
         |> ExSieve.HTML.sort_link(:name, "test", to: &(assert_params_path(conn, :search, &1)))
         |> Phoenix.HTML.safe_to_string
 


### PR DESCRIPTION
When two field starts with same part sort_link helper sorting arrow at both.
